### PR TITLE
Fixed UnicodeEncodeError (print response['title']) and added an exception handler

### DIFF
--- a/offers_scraper.py
+++ b/offers_scraper.py
@@ -86,7 +86,6 @@ def main():
             offers.append(offer)
         else:
             print(': {}'.format(json.loads(r.content)['error']))
-            
     with open(__output_file__, 'w') as f:
          f.write(json.dumps(offers))
 

--- a/offers_scraper.py
+++ b/offers_scraper.py
@@ -27,7 +27,7 @@ __end_id__ = 20000
 
 
 def main():
-    non_bmp_map = dict.fromkeys(range(0x10000, sys.maxunicode + 1), 0xfffd)
+    non_bmp_map = dict.fromkeys(range(0x10000, sys.maxunicode + 1), 0xfffd) #used to print the offer title without a unicode error
     print('Starting scraping {num} offers using mcdapi ({version})...'.format(num=(__end_id__ - __start_id__ + 1),
                                                                               version=mcdapi.__version__))
     start_time = datetime.now()

--- a/offers_scraper.py
+++ b/offers_scraper.py
@@ -63,12 +63,18 @@ def main():
     for x in range(__start_id__, __end_id__ + 1):
         print('Requesting offer {}... '.format(x), end='')
 
-        plexure = coupon.generate_plexure_api_key(vmob)
-        headers['x-plexure-api-key'] = plexure
-        session.headers.update(headers)
+        try:
+            plexure = coupon.generate_plexure_api_key(vmob)
+            headers['x-plexure-api-key'] = plexure
+            session.headers.update(headers)
 
-        r = session.request(endpoints.REDEEM_OFFER['method'], endpoints.REDEEM_OFFER['url'],
-                            data=endpoints.REDEEM_OFFER['body'].format(id=x))
+            r = session.request(endpoints.REDEEM_OFFER['method'], endpoints.REDEEM_OFFER['url'],
+                                data=endpoints.REDEEM_OFFER['body'].format(id=x))
+        except Exception:
+            print("Exception caught while scraping the offer {}".format(x))
+            with open(__output_file__, 'w') as f:
+                f.write(json.dumps(offers))
+            continue
 
         print('Got a response with code {}'.format(r.status_code), end='')
 

--- a/offers_scraper.py
+++ b/offers_scraper.py
@@ -28,12 +28,9 @@ __end_id__ = 20000
 
 def main():
     non_bmp_map = dict.fromkeys(range(0x10000, sys.maxunicode + 1), 0xfffd)
-    
     print('Starting scraping {num} offers using mcdapi ({version})...'.format(num=(__end_id__ - __start_id__ + 1),
                                                                               version=mcdapi.__version__))
-
     start_time = datetime.now()
-
     session = requests.session()
 
     if __proxy_enabled__:


### PR DESCRIPTION
Fixed the following error:

print(': {} [{} - {}]'.format(response['title'], response['startDate'], response['endDate']))
UnicodeEncodeError: 'UCS-2' codec can't encode characters in position 53-53: Non-BMP character not supported in Tk

by translating everything outside of the BMP to the replacement character.

Also I put

with open(__output_file__, 'w') as f:
         f.write(json.dumps(offers))

at the end of the main instead of inside the loop, so the program doesn't become an I/O bound program.